### PR TITLE
Fix: Prevent page from scrolling when a modal is open

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "BSMon",
+  "name": "app",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "app",
+  "name": "BSMon",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/static/style.css
+++ b/static/style.css
@@ -362,6 +362,7 @@ main {
     background-color: rgba(0, 0, 0, 0.5);
     justify-content: center;
     align-items: center;
+    overscroll-behavior: contain;
 }
 
 .modal.hidden {


### PR DESCRIPTION
When the chart or raw data modal was open, the main page in the background could still be scrolled.

This change prevents this by adding `overscroll-behavior: contain;` to the modal's CSS. This is a modern CSS property that prevents scroll events from bubbling up from the modal to the main page, effectively containing the scroll within the modal. This provides an elegant, CSS-only solution to the problem.

Note: The existing test suite has some failures that appear to be unrelated to these changes. The VAPID key configuration in `settings-default.json` causes several tests to fail, and there are also some pre-existing failures in `logger.test.js`. These issues are not addressed in this commit.

[From Google Jules AI coding agent]